### PR TITLE
Add `attributes` and `tags` to modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 module "subnets" {
@@ -16,6 +19,9 @@ module "subnets" {
   vpc_id             = "${aws_vpc.default.id}"
   cidr_block         = "${aws_vpc.default.cidr_block}"
   igw_id             = "${aws_internet_gateway.default.id}"
+  delimiter          = "${var.delimiter}"
+  attributes         = ["${compact(concat(var.attributes, list("subnets")))}"]
+  tags               = "${var.tags}"
 }
 
 resource "aws_vpc" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,21 @@ variable "cidr_block" {
 variable "region" {
   type = "string"
 }
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+}


### PR DESCRIPTION
## What

* Added `attributes` and `tags` to modules


## Why

* So we could assign arbitrary tags to the AWS resources

