### PR TITLE
Remove subnets module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "vpc" {
 
 | Name                               |    Default    | Description                                                                      | Required |
 |:-----------------------------------|:-------------:|:---------------------------------------------------------------------------------|:--------:|
+| `create_vpc`                       |    `true`     | Flag of creation VPC                                                             |    No    |
 | `assign_generated_ipv6_cidr_block` |    `false`    | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC |    No    |
 | `cidr_block`                       | `10.0.0.0/16` | CIDR for the VPC                                                                 |    No    |
 | `enable_classiclink`               |    `false`    | A boolean flag to enable/disable ClassicLink for the VPC                         |    No    |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module "vpc" {
 }
 ```
 
-* Completive example with [`terraform-aws-dynamic-subnets`](https://github.com/cloudposse/terraform-aws-dynamic-subnets.git):
+* Full example with [`terraform-aws-dynamic-subnets`](https://github.com/cloudposse/terraform-aws-dynamic-subnets.git):
 
 ```terraform
 module "vpc" {

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Terraform module that defines a VPC with Internet Gateway
 
 ```terraform
 module "vpc" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   name      = "${var.name}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "dynamic_subnets" {
   region             = "${var.region}"
   vpc_id             = "${module.vpc.vpc_id}"
   igw_id             = "${module.vpc.igw_id}"
-  cidr_block         = "10.0.0.0/24"
+  cidr_block         = "${module.vpc.vpc_cidr_block}"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ module "vpc" {
 | `enable_dns_hostnames`             |    `true`     | A boolean flag to enable/disable DNS hostnames in the VPC                        |    No    |
 | `enable_dns_support`               |    `true`     | A boolean flag to enable/disable DNS support in the VPC                          |    No    |
 | `instance_tenancy`                 |      ``       | A tenancy option for instances launched into the VPC                             |    No    |
-| `name`                             |      ``       |                                                                                  |   Yes    |
-| `namespace`                        |      ``       |                                                                                  |   Yes    |
-| `stage`                            |      ``       |                                                                                  |   Yes    |
-| `tags`                             |     `{}`      | Additional tags (e.g. `map('BusinessUnit`,`XYZ`)                                 |    No    |
-| `attributes`                       |      ``       | Additional attributes (e.g. `policy` or `role`)                                  |    No    |
+| `namespace`                        |      ``       | Namespace (e.g. `cp` or `cloudposse`)                                            |   Yes    |
+| `stage`                            |      ``       | Stage (e.g. `prod`, `dev`, `staging`)                                            |   Yes    |
+| `name`                             |      ``       | Name  (e.g. `bastion` or `db`)                                                   |   Yes    |
+| `attributes`                       |     `[]`      | Additional attributes (e.g. `policy` or `role`)                                  |    No    |
+| `tags`                             |     `{}`      | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                               |    No    |
 | `delimiter`                        |      `-`      | Delimiter to be used between `name`, `namespace`, `stage`, etc.                  |    No    |
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ module "vpc" {
 
 | Name                               |    Default    | Description                                                                      | Required |
 |:-----------------------------------|:-------------:|:---------------------------------------------------------------------------------|:--------:|
-| `create_vpc`                       |    `true`     | Flag of creation VPC                                                             |    No    |
 | `assign_generated_ipv6_cidr_block` |    `false`    | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC |    No    |
 | `cidr_block`                       | `10.0.0.0/16` | CIDR for the VPC                                                                 |    No    |
 | `enable_classiclink`               |    `false`    | A boolean flag to enable/disable ClassicLink for the VPC                         |    No    |

--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ module "vpc" {
 }
 
 module "dynamic_subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-
+  source             = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
   availability_zones = "${var.availability_zones}"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"
   region             = "${var.region}"
-  vpc_id             = "${module.vpc_id}"
-  igw_id             = "${module.igw_id}"
-  cidr_block         = "10.0.0.0/16"
+  vpc_id             = "${module.vpc.vpc_id}"
+  igw_id             = "${module.vpc.igw_id}"
+  cidr_block         = "10.0.0.0/24"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,52 @@
 # terraform-aws-vpc
 
-Terraform module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways
+Terraform module that defines a VPC with Internet Gateway
+
+
+## Usage
+
+```terraform
+module "vpc" {
+  name      = "${var.name}"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+}
+```
+
+## Inputs
+
+| Name                               |    Default    | Description                                                                      | Required |
+|:-----------------------------------|:-------------:|:---------------------------------------------------------------------------------|:--------:|
+| `assign_generated_ipv6_cidr_block` |    `false`    | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC |    No    |
+| `cidr_block`                       | `10.0.0.0/16` | CIDR for the VPC                                                                 |    No    |
+| `enable_classiclink`               |    `false`    | A boolean flag to enable/disable ClassicLink for the VPC                         |    No    |
+| `enable_classiclink_dns_support`   |    `false`    | A boolean flag to enable/disable ClassicLink DNS Support for the VPC             |    No    |
+| `enable_dns_hostnames`             |    `true`     | A boolean flag to enable/disable DNS hostnames in the VPC                        |    No    |
+| `enable_dns_support`               |    `true`     | A boolean flag to enable/disable DNS support in the VPC                          |    No    |
+| `instance_tenancy`                 |      ``       | A tenancy option for instances launched into the VPC                             |    No    |
+| `name`                             |      ``       |                                                                                  |   Yes    |
+| `namespace`                        |      ``       |                                                                                  |   Yes    |
+| `stage`                            |      ``       |                                                                                  |   Yes    |
+| `tags`                             |     `{}`      | Additional tags (e.g. `map('BusinessUnit`,`XYZ`)                                 |    No    |
+| `attributes`                       |      ``       | Additional attributes (e.g. `policy` or `role`)                                  |    No    |
+| `delimiter`                        |      `-`      | Delimiter to be used between `name`, `namespace`, `stage`, etc.                  |    No    |
+
+
+
+## Outputs
+
+| Name                            | Description                                                     |
+|:--------------------------------|:----------------------------------------------------------------|
+| `igw_id`                        | The ID of the Internet Gateway                                  |
+| `ipv6_cidr_block`               | The IPv6 CIDR block                                             |
+| `vpc_cidr_block`                | The CIDR block of the VPC                                       |
+| `vpc_default_network_acl_id`    | The ID of the network ACL created by default on VPC creation    |
+| `vpc_default_route_table_id`    | The ID of the route table created by default on VPC creation    |
+| `vpc_default_security_group_id` | The ID of the security group created by default on VPC creation |
+| `vpc_id`                        | The ID of the VPC                                               |
+| `vpc_ipv6_association_id`       | The association ID for the IPv6 CIDR block                      |
+| `vpc_main_route_table_id`       | The ID of the main route table associated with this VPC.        |
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # terraform-aws-vpc
 
-Terraform module that defines a VPC with Internet Gateway
+Terraform module that defines a VPC with Internet Gateway.
 
 
 ## Usage
+
+* Quick start example:
 
 ```terraform
 module "vpc" {
@@ -11,6 +13,30 @@ module "vpc" {
   name      = "${var.name}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
+}
+```
+
+* Completive example with [`terraform-aws-dynamic-subnets`](https://github.com/cloudposse/terraform-aws-dynamic-subnets.git):
+
+```terraform
+module "vpc" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
+  name      = "${var.name}"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+}
+
+module "dynamic_subnets" {
+  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
+
+  availability_zones = "${var.availability_zones}"
+  namespace          = "${var.namespace}"
+  name               = "${var.name}"
+  stage              = "${var.stage}"
+  region             = "${var.region}"
+  vpc_id             = "${module.vpc_id}"
+  igw_id             = "${module.igw_id}"
+  cidr_block         = "10.0.0.0/16"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "label" {
 }
 
 resource "aws_vpc" "default" {
+  count                            = "${var.create_vpc ? 1 : 0}"
   cidr_block                       = "${var.cidr_block}"
   instance_tenancy                 = "${var.instance_tenancy}"
   enable_dns_hostnames             = "${var.enable_dns_hostnames}"
@@ -21,6 +22,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_internet_gateway" "default" {
+  count  = "${var.create_vpc ? 1 : 0}"
   vpc_id = "${aws_vpc.default.id}"
   tags   = "${module.label.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -9,25 +9,15 @@ module "label" {
   tags       = "${var.tags}"
 }
 
-module "subnets" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.2.3"
-  availability_zones = "${var.availability_zones}"
-  namespace          = "${var.namespace}"
-  name               = "${var.name}"
-  stage              = "${var.stage}"
-  region             = "${var.region}"
-  vpc_id             = "${aws_vpc.default.id}"
-  cidr_block         = "${aws_vpc.default.cidr_block}"
-  igw_id             = "${aws_internet_gateway.default.id}"
-  delimiter          = "${var.delimiter}"
-  attributes         = ["${compact(concat(var.attributes, list("subnets")))}"]
-  tags               = "${var.tags}"
-}
-
 resource "aws_vpc" "default" {
-  cidr_block           = "${var.cidr_block}"
-  enable_dns_hostnames = true
-  tags                 = "${module.label.tags}"
+  cidr_block                       = "${var.cidr_block}"
+  instance_tenancy                 = "${var.instance_tenancy}"
+  enable_dns_hostnames             = "${var.enable_dns_hostnames}"
+  enable_dns_support               = "${var.enable_dns_support}"
+  enable_classiclink               = "${var.enable_classiclink}"
+  enable_classiclink_dns_support   = "${var.enable_classiclink_dns_support}"
+  assign_generated_ipv6_cidr_block = "${var.assign_generated_ipv6_cidr_block}"
+  tags                             = "${module.label.tags}"
 }
 
 resource "aws_internet_gateway" "default" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ module "label" {
 }
 
 resource "aws_vpc" "default" {
-  count                            = "${var.create_vpc ? 1 : 0}"
   cidr_block                       = "${var.cidr_block}"
   instance_tenancy                 = "${var.instance_tenancy}"
   enable_dns_hostnames             = "${var.enable_dns_hostnames}"
@@ -22,7 +21,6 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_internet_gateway" "default" {
-  count  = "${var.create_vpc ? 1 : 0}"
   vpc_id = "${aws_vpc.default.id}"
   tags   = "${module.label.tags}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,6 @@ output "vpc_ipv6_association_id" {
 }
 
 output "ipv6_cidr_block" {
-  value       = "${aws_vpc.default.ipv6_cidr_block }"
+  value       = "${aws_vpc.default.ipv6_cidr_block}"
   description = "The IPv6 CIDR block"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,44 @@
+output "igw_id" {
+  value       = "${aws_internet_gateway.default.id}"
+  description = "The ID of the Internet Gateway"
+}
+
 output "vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value       = "${aws_vpc.default.id}"
+  description = "The ID of the VPC"
 }
 
-output "public_subnet_ids" {
-  value = ["${module.subnets.public_subnet_ids}"]
+output "vpc_cidr_block" {
+  value       = "${aws_vpc.default.cidr_block}"
+  description = "The CIDR block of the VPC"
 }
 
-output "private_subnet_ids" {
-  value = ["${module.subnets.private_subnet_ids}"]
+output "vpc_main_route_table_id" {
+  value       = "${aws_vpc.default.main_route_table_id}"
+  description = "The ID of the main route table associated with this VPC."
+}
+
+output "vpc_default_network_acl_id" {
+  value       = "${aws_vpc.default.default_network_acl_id}"
+  description = "The ID of the network ACL created by default on VPC creation"
+}
+
+output "vpc_default_security_group_id" {
+  value       = "${aws_vpc.default.default_security_group_id}"
+  description = "The ID of the security group created by default on VPC creation"
+}
+
+output "vpc_default_route_table_id" {
+  value       = "${aws_vpc.default.default_route_table_id}"
+  description = "The ID of the route table created by default on VPC creation"
+}
+
+output "vpc_ipv6_association_id" {
+  value       = "${aws_vpc.default.ipv6_association_id}"
+  description = "The association ID for the IPv6 CIDR block"
+}
+
+output "ipv6_cidr_block" {
+  value       = "${aws_vpc.default.ipv6_cidr_block }"
+  description = "The IPv6 CIDR block"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,21 +10,6 @@ variable "name" {
   type = "string"
 }
 
-variable "availability_zones" {
-  description = "List of Availability Zones"
-  type        = "list"
-}
-
-variable "cidr_block" {
-  type        = "string"
-  description = "CIDR for the VPC"
-  default     = "10.0.0.0/16"
-}
-
-variable "region" {
-  type = "string"
-}
-
 variable "delimiter" {
   type        = "string"
   default     = "-"
@@ -41,4 +26,40 @@ variable "tags" {
   type        = "map"
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+}
+
+variable "cidr_block" {
+  type        = "string"
+  description = "CIDR for the VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "instance_tenancy" {
+  description = "A tenancy option for instances launched into the VPC"
+  default     = ""
+}
+
+variable "enable_dns_hostnames" {
+  description = "A boolean flag to enable/disable DNS hostnames in the VPC"
+  default     = "true"
+}
+
+variable "enable_dns_support" {
+  description = "A boolean flag to enable/disable DNS support in the VPC"
+  default     = "true"
+}
+
+variable "enable_classiclink" {
+  description = "A boolean flag to enable/disable ClassicLink for the VPC"
+  default     = "false"
+}
+
+variable "enable_classiclink_dns_support" {
+  description = "A boolean flag to enable/disable ClassicLink DNS Support for the VPC"
+  default     = "false"
+}
+
+variable "assign_generated_ipv6_cidr_block" {
+  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC"
+  default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,10 +31,6 @@ variable "tags" {
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
 
-variable "create_vpc" {
-  default = "true"
-}
-
 variable "cidr_block" {
   type        = "string"
   description = "CIDR for the VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,16 @@
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
   type        = "string"
-  default     = "cp"
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
   type        = "string"
-  default     = "dev"
 }
 
 variable "name" {
   description = "Name  (e.g. `bastion` or `db`)"
   type        = "string"
-  default     = "subnet"
 }
 
 variable "delimiter" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,10 @@ variable "tags" {
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
 
+variable "create_vpc" {
+  default = "tre"
+}
+
 variable "cidr_block" {
   type        = "string"
   description = "CIDR for the VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,19 @@
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
   type        = "string"
+  default     = "cp"
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
   type        = "string"
+  default     = "dev"
 }
 
 variable "name" {
   description = "Name  (e.g. `bastion` or `db`)"
   type        = "string"
+  default     = "subnet"
 }
 
 variable "delimiter" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "tags" {
 }
 
 variable "create_vpc" {
-  default = "tre"
+  default = "true"
 }
 
 variable "cidr_block" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,16 @@
 variable "namespace" {
-  type = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  type        = "string"
 }
 
 variable "stage" {
-  type = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  type        = "string"
 }
 
 variable "name" {
-  type = "string"
+  description = "Name  (e.g. `bastion` or `db`)"
+  type        = "string"
 }
 
 variable "delimiter" {


### PR DESCRIPTION
## What
* Exclude `terraform-aws-dynamic-subnets` module
* Update README

## Why
* Provision only general VPC components with `terraform-aws-vpc` 
* Make `subnets` module plugable (e.g. we would be able to use any `subnets` module with `terraform-aws-dynamic-subnets` module)