### PR TITLE
Set default `instance_tenancy` to `default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module that defines a VPC with Internet Gateway.
 
 * Quick start example:
 
-```terraform
+```hcl
 module "vpc" {
   source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   name      = "${var.name}"
@@ -18,7 +18,7 @@ module "vpc" {
 
 * Full example with [`terraform-aws-dynamic-subnets`](https://github.com/cloudposse/terraform-aws-dynamic-subnets.git):
 
-```terraform
+```hcl
 module "vpc" {
   source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   name      = "${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "cidr_block" {
 
 variable "instance_tenancy" {
   description = "A tenancy option for instances launched into the VPC"
-  default     = ""
+  default     = "default"
 }
 
 variable "enable_dns_hostnames" {


### PR DESCRIPTION
## what
* Set default `instance_tenancy` to `default`

## why
* Use s3 backend for `.tfstate` file
* Do `terraform apply` on one host
* Do `terraform plan` on another host
* VPC is going to be recreated because `instance_tenancy` is changed

![image](https://user-images.githubusercontent.com/11299538/33437965-332f1a18-d5f2-11e7-97b0-d27e9c7795d0.png)

## references
* https://www.terraform.io/docs/providers/aws/r/vpc.html#instance_tenancy
* http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpc.html
