### PR TITLE
Force `assign_generated_ipv6_cidr_block`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - make init
 
 script:
-  - make terraform:install
-  - make terraform:get-plugins
-  - make terraform:get-modules
-  - make terraform:lint
-  - make terraform:validate
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ SHELL := /bin/bash
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 
 lint:
-	$(SELF) terraform:install terraform:get-modules terraform:get-plugins terraform:lint terraform:validate
+	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# terraform-aws-vpc [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-vpc.svg)](https://travis-ci.org/cloudposse/terraform-aws-vpc)
+# terraform-aws-vpc [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-vpc.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-vpc)
 
-Terraform module that defines a VPC with Internet Gateway.
+Terraform module to provision a VPC with Internet Gateway.
 
 
 ## Usage
@@ -10,9 +10,9 @@ Terraform module that defines a VPC with Internet Gateway.
 ```hcl
 module "vpc" {
   source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-  name      = "${var.name}"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
+  namespace = "cp"
+  stage     = "prod"
+  name      = "app"
 }
 ```
 
@@ -21,41 +21,41 @@ module "vpc" {
 ```hcl
 module "vpc" {
   source    = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-  name      = "${var.name}"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
+  namespace = "cp"
+  stage     = "prod"
+  name      = "app"
 }
 
 module "dynamic_subnets" {
   source             = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
-  availability_zones = "${var.availability_zones}"
-  namespace          = "${var.namespace}"
-  name               = "${var.name}"
-  stage              = "${var.stage}"
-  region             = "${var.region}"
+  namespace          = "cp"
+  stage              = "prod"
+  name               = "app"
+  region             = "us-west-2"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   vpc_id             = "${module.vpc.vpc_id}"
   igw_id             = "${module.vpc.igw_id}"
-  cidr_block         = "${module.vpc.vpc_cidr_block}"
+  cidr_block         = "10.0.0.0/16"
 }
 ```
+
 
 ## Inputs
 
 | Name                               |    Default    | Description                                                                      | Required |
 |:-----------------------------------|:-------------:|:---------------------------------------------------------------------------------|:--------:|
-| `assign_generated_ipv6_cidr_block` |    `false`    | Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC |    No    |
-| `cidr_block`                       | `10.0.0.0/16` | CIDR for the VPC                                                                 |    No    |
+| `namespace`                        |      ``       | Namespace (e.g. `cp` or `cloudposse`)                                            |   Yes    |
+| `stage`                            |      ``       | Stage (e.g. `prod`, `dev`, `staging`)                                            |   Yes    |
+| `name`                             |      ``       | Name  (e.g. `app` or `cluster`)                                                  |   Yes    |
+| `cidr_block`                       | `10.0.0.0/16` | CIDR block for the VPC                                                           |    No    |
 | `enable_classiclink`               |    `false`    | A boolean flag to enable/disable ClassicLink for the VPC                         |    No    |
 | `enable_classiclink_dns_support`   |    `false`    | A boolean flag to enable/disable ClassicLink DNS Support for the VPC             |    No    |
 | `enable_dns_hostnames`             |    `true`     | A boolean flag to enable/disable DNS hostnames in the VPC                        |    No    |
 | `enable_dns_support`               |    `true`     | A boolean flag to enable/disable DNS support in the VPC                          |    No    |
-| `instance_tenancy`                 |      ``       | A tenancy option for instances launched into the VPC                             |    No    |
-| `namespace`                        |      ``       | Namespace (e.g. `cp` or `cloudposse`)                                            |   Yes    |
-| `stage`                            |      ``       | Stage (e.g. `prod`, `dev`, `staging`)                                            |   Yes    |
-| `name`                             |      ``       | Name  (e.g. `bastion` or `db`)                                                   |   Yes    |
-| `attributes`                       |     `[]`      | Additional attributes (e.g. `policy` or `role`)                                  |    No    |
+| `instance_tenancy`                 |   `default`   | A tenancy option for instances launched into the VPC                             |    No    |
+| `attributes`                       |     `[]`      | Additional attributes (e.g. `1`)                                                 |    No    |
 | `tags`                             |     `{}`      | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                               |    No    |
-| `delimiter`                        |      `-`      | Delimiter to be used between `name`, `namespace`, `stage`, etc.                  |    No    |
+| `delimiter`                        |     `-`       | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       |    No    |
 
 
 
@@ -75,6 +75,85 @@ module "dynamic_subnets" {
 
 
 
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-vpc/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-vpc/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-vpc`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
+
+
 ## License
 
-Apache 2 License. See [`LICENSE`](LICENSE) for full details.
+[APACHE 2.0](LICENSE) © 2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+## About
+
+`terraform-aws-vpc` is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+## Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img]
+|-------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+
+[erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+[erik_web]: https://github.com/osterman/
+[andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+[andriy_web]: https://github.com/aknysh/
+[igor_img]: http://s.gravatar.com/avatar/bc70834d32ed4517568a1feb0b9be7e2?s=144
+[igor_web]: https://github.com/goruha/

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"
@@ -15,7 +15,7 @@ resource "aws_vpc" "default" {
   enable_dns_support               = "${var.enable_dns_support}"
   enable_classiclink               = "${var.enable_classiclink}"
   enable_classiclink_dns_support   = "${var.enable_classiclink_dns_support}"
-  assign_generated_ipv6_cidr_block = "${var.assign_generated_ipv6_cidr_block}"
+  assign_generated_ipv6_cidr_block = true
   tags                             = "${module.label.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,26 +9,26 @@ variable "stage" {
 }
 
 variable "name" {
-  description = "Name  (e.g. `bastion` or `db`)"
+  description = "Name  (e.g. `app` or `cluster`)"
   type        = "string"
 }
 
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "cidr_block" {
@@ -59,10 +59,5 @@ variable "enable_classiclink" {
 
 variable "enable_classiclink_dns_support" {
   description = "A boolean flag to enable/disable ClassicLink DNS Support for the VPC"
-  default     = "false"
-}
-
-variable "assign_generated_ipv6_cidr_block" {
-  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC"
   default     = "false"
 }


### PR DESCRIPTION
## what
* Force `assign_generated_ipv6_cidr_block`

## why
* To address the issue https://github.com/cloudposse/terraform-aws-vpc/issues/15
* To fix Terraform errors if `assign_generated_ipv6_cidr_block` is set to `false`

```
* module.vpc.output.vpc_ipv6_association_id: Resource 'aws_vpc.default' does not have attribute 'ipv6_association_id' for variable 'aws_vpc.default.ipv6_association_id'
* module.vpc.output.ipv6_cidr_block: Resource 'aws_vpc.default' does not have attribute 'ipv6_cidr_block' for variable 'aws_vpc.default.ipv6_cidr_block'
```

* Assigning an IPv6 CIDR block to VPC does not consume any additional resources and does not cost anything
