### PR TITLE
Update variables.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,12 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| cidr_block | CIDR for the VPC | string | `10.0.0.0/16` | no |
+| cidr_block | CIDR for the VPC | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | enable_classiclink | A boolean flag to enable/disable ClassicLink for the VPC | string | `false` | no |
 | enable_classiclink_dns_support | A boolean flag to enable/disable ClassicLink DNS Support for the VPC | string | `false` | no |
@@ -206,7 +205,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,10 +1,9 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| cidr_block | CIDR for the VPC | string | `10.0.0.0/16` | no |
+| cidr_block | CIDR for the VPC | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | enable_classiclink | A boolean flag to enable/disable ClassicLink for the VPC | string | `false` | no |
 | enable_classiclink_dns_support | A boolean flag to enable/disable ClassicLink DNS Support for the VPC | string | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,6 @@ variable "tags" {
 variable "cidr_block" {
   type        = "string"
   description = "CIDR for the VPC"
-  default     = "10.0.0.0/16"
 }
 
 variable "instance_tenancy" {


### PR DESCRIPTION
## what
* Remove default VPC CIDR range

## Why

* I think it would be better to declare the CIDR rather than default to use 10.0.0.0. 

## use-case

* I was using the example in the README but wanted to use the 10.8.0.0/16 range and got errors until I discovered the VPC module had assumed 10.0.0.0 by default.