### PR TITLE
Correctly pin `aws` provider

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,8 @@ terraform {
 
 # Pin the `aws` provider
 # https://www.terraform.io/docs/configuration/providers.html
+# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
 provider "aws" {
-  version = ">= 2.12.0"
+  version = "~> 2.0"
   region  = var.region
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,7 @@ terraform {
 
 # Pin the `aws` provider
 # https://www.terraform.io/docs/configuration/providers.html
+# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
 provider "aws" {
-  version = ">= 2.12.0"
+  version = "~> 2.0"
 }


### PR DESCRIPTION
## what
* Correctly pin `aws` provider

## why
* Allow any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y

## references
* https://www.terraform.io/docs/configuration/providers.html
