### PR TITLE
Use `required_providers` to pin Terraform providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Available targets:
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |
 | instance_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map(string) | `<map>` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,8 +11,8 @@
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |
 | instance_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map(string) | `<map>` | no |
 
 ## Outputs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,10 +1,6 @@
 module "vpc" {
   source = "../../"
 
-  providers = {
-    aws = "aws"
-  }
-
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -12,7 +8,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.13.1"
+  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.15.0"
 
   providers = {
     aws = "aws"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 }
 
-# Pin the `aws` provider
-# https://www.terraform.io/docs/configuration/providers.html
-# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
 provider "aws" {
-  version = "~> 2.0"
-  region  = var.region
+  region = var.region
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.13.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -1,4 +1,4 @@
-PACKAGE  = terraform-aws-dynamic-subnets
+PACKAGE  = terraform-aws-vpc
 GOEXE   ?= /usr/bin/go
 GOPATH   = $(CURDIR)/.gopath
 GOBIN    = $(GOPATH)/bin

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,13 @@
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
   type        = string
+  default     = ""
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
   type        = string
+  default     = ""
 }
 
 variable "name" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = "~> 0.12.0"
-}
 
-# Pin the `aws` provider
-# https://www.terraform.io/docs/configuration/providers.html
-# Any non-beta version >= 2.0.0 and < 3.0.0, e.g. 2.X.Y
-provider "aws" {
-  version = "~> 2.0"
+  required_providers {
+    aws      = "~> 2.0"
+    template = "~> 2.0"
+    local    = "~> 1.2"
+    null     = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## what
* Use `required_providers` to pin Terraform providers

## why
* Pinning the module's providers version in `required_providers` block allows specifying only the required provider version for the module without the need to specify all providers with versions explicitly
