### PR TITLE
Properly pin providers in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ```hcl
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-  namespace  = "cp"
-  stage      = "prod"
+  namespace  = "eg"
+  stage      = "test"
   name       = "app"
   cidr_block = "10.0.0.0/16"
 }
@@ -62,7 +62,7 @@ Full example with [`terraform-aws-dynamic-subnets`](https://github.com/cloudposs
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   namespace  = "eg"
-  stage      = "prod"
+  stage      = "test"
   name       = "app"
   cidr_block = "10.0.0.0/16"
 }
@@ -70,7 +70,7 @@ module "vpc" {
 module "dynamic_subnets" {
   source             = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
   namespace          = "eg"
-  stage              = "prod"
+  stage              = "test"
   name               = "app"
   region             = "us-west-2"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]

--- a/README.yaml
+++ b/README.yaml
@@ -70,8 +70,8 @@ examples: |-
   ```hcl
   module "vpc" {
     source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
-    namespace  = "cp"
-    stage      = "prod"
+    namespace  = "eg"
+    stage      = "test"
     name       = "app"
     cidr_block = "10.0.0.0/16"
   }
@@ -83,7 +83,7 @@ examples: |-
   module "vpc" {
     source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
     namespace  = "eg"
-    stage      = "prod"
+    stage      = "test"
     name       = "app"
     cidr_block = "10.0.0.0/16"
   }
@@ -91,7 +91,7 @@ examples: |-
   module "dynamic_subnets" {
     source             = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
     namespace          = "eg"
-    stage              = "prod"
+    stage              = "test"
     name               = "app"
     region             = "us-west-2"
     availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -4,6 +4,6 @@ availability_zones = ["us-west-1b", "us-west-1c"]
 
 namespace = "eg"
 
-name = "vpc-subnets"
-
 stage = "test"
+
+name = "vpc-subnets"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,9 @@
-module "vpc" {
-  source = "../../"
+provider "aws" {
+  region = var.region
+}
 
+module "vpc" {
+  source     = "../../"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -8,12 +11,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.15.0"
-
-  providers = {
-    aws = "aws"
-  }
-
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.15.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,7 +1,0 @@
-terraform {
-  required_version = "~> 0.12.0"
-}
-
-provider "aws" {
-  region = var.region
-}


### PR DESCRIPTION
## what
* Properly pin providers in the example

## why
* We don't use `providers` block to send providers to modules
* Use `required_providers` in `terraform` block to pin provider versions

and 
```
provider "aws" {
  region = var.region
}
```
in top-level modules/examples to specify the region
