### PR TITLE
Address CIS-VpcDefaultSecurityGroupsMustRestrictAllTraffic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,14 @@ resource "aws_vpc" "default" {
   tags                             = module.label.tags
 }
 
+resource "aws_default_security_group" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags = {
+    Name = "Default Security Group"
+  }
+}
+
 resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.default.id
   tags   = module.label.tags

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
     Name = "Default Security Group"

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_vpc" "default" {
   tags                             = module.label.tags
 }
 
+# If `aws_default_security_group` is not defined, it would be created implicitly with access `0.0.0.0/0`
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.default.id
 


### PR DESCRIPTION
## What
* Explicit declare `aws_default_security_group` without any `security_group_rule`

## Why
* Address `CIS-VpcDefaultSecurityGroupsMustRestrictAllTraffic`
* If `aws_default_security_group` is not defined, it would be created implicitly with access `0.0.0.0/0`
