### PR TITLE
Pass `environment` argument to label module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform module to provision a VPC with Internet Gateway.
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
 [<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
 [<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
 [<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
@@ -32,7 +32,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out! 
+We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
 
 
 
@@ -103,6 +103,7 @@ Available targets:
 | enable_classiclink_dns_support | A boolean flag to enable/disable ClassicLink DNS Support for the VPC | bool | `false` | no |
 | enable_dns_hostnames | A boolean flag to enable/disable DNS hostnames in the VPC | bool | `true` | no |
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |
+| environment | Environment (e.g. `prod`, `staging`, `dev`, `pre-prod`, `UAT`) | string | `` | no |
 | instance_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
@@ -126,9 +127,9 @@ Available targets:
 
 
 
-## Share the Love 
+## Share the Love
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-vpc)! (it helps us **a lot**) 
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-vpc)! (it helps us **a lot**)
 
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
@@ -155,9 +156,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-vpc/issues), s
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)][email]
 
@@ -167,7 +168,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll [develop original modules][module_development] to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 
@@ -182,7 +183,7 @@ Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Ou
 
 ## Newsletter
 
-Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
+Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
 
 ## Contributing
 
@@ -211,9 +212,9 @@ Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,6 +9,7 @@
 | enable_classiclink_dns_support | A boolean flag to enable/disable ClassicLink DNS Support for the VPC | bool | `false` | no |
 | enable_dns_hostnames | A boolean flag to enable/disable DNS hostnames in the VPC | bool | `true` | no |
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |
+| environment | Environment (e.g. `prod`, `staging`, `dev`, `pre-prod`, `UAT`) | string | `` | no |
 | instance_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
@@ -28,4 +29,3 @@
 | vpc_id | The ID of the VPC |
 | vpc_ipv6_association_id | The association ID for the IPv6 CIDR block |
 | vpc_main_route_table_id | The ID of the main route table associated with this VPC |
-

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
-  namespace  = var.namespace
-  name       = var.name
-  stage      = var.stage
-  delimiter  = var.delimiter
-  attributes = var.attributes
-  tags       = var.tags
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.0"
+  namespace   = var.namespace
+  environment = var.environment
+  name        = var.name
+  stage       = var.stage
+  delimiter   = var.delimiter
+  attributes  = var.attributes
+  tags        = var.tags
 }
 
 resource "aws_vpc" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "namespace" {
   default     = ""
 }
 
+variable "environment" {
+  description = "Environment (e.g. `prod`, `staging`, `dev`, `pre-prod`, `UAT`)"
+  type        = string
+  default     = ""
+}
+
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
   type        = string
@@ -67,4 +73,3 @@ variable "enable_classiclink_dns_support" {
   description = "A boolean flag to enable/disable ClassicLink DNS Support for the VPC"
   default     = false
 }
-


### PR DESCRIPTION
According to [terraform-null-label](https://github.com/cloudposse/terraform-null-label), a label follows the following naming convention: ` {namespace}-{environment}-{stage}-{name}-{attributes}`. However, using the `environment` argument in this module produces an error:
```
An argument named "environment" is not expected here.
```
This pull request fixes this error by passing `environment` as an argument to the label module.