### PR TITLE
Remove unused "region" variable from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,15 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [drama17_homepage]: https://github.com/drama17
-  [drama17_avatar]: https://github.com/drama17.png?size=150
+  [drama17_avatar]: https://img.cloudposse.com/150x150/https://github.com/drama17.png
   [SweetOps_homepage]: https://github.com/SweetOps
-  [SweetOps_avatar]: https://github.com/SweetOps.png?size=150
+  [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
 
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ module "dynamic_subnets" {
   namespace          = "eg"
   stage              = "test"
   name               = "app"
-  region             = "us-west-2"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   vpc_id             = module.vpc.vpc_id
   igw_id             = module.vpc.igw_id

--- a/README.yaml
+++ b/README.yaml
@@ -93,7 +93,6 @@ examples: |-
     namespace          = "eg"
     stage              = "test"
     name               = "app"
-    region             = "us-west-2"
     availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
     vpc_id             = module.vpc.vpc_id
     igw_id             = module.vpc.igw_id


### PR DESCRIPTION
## what
Removes usage of the `region` variable from documentation.

## why
Historically `region` may have been a variable that could be passed to the `terraform-aws-dynamic-subnets` module, but currently it looks like it no longer is.

Relates to: https://github.com/cloudposse/terraform-aws-dynamic-subnets/pull/74