### PR TITLE
Add an optional boolean flag to requests an Amazon-provided IPv6 CIDR…

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,7 @@
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | enable_classiclink | A boolean flag to enable/disable ClassicLink for the VPC | bool | `false` | no |
 | enable_classiclink_dns_support | A boolean flag to enable/disable ClassicLink DNS Support for the VPC | bool | `false` | no |
+| assign_generated_ipv6_cidr_block | A boolean flag to requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC | bool | `false` | no |
 | enable_default_security_group_with_custom_rules | A boolean flag to enable/disable custom and restricive inbound/outbound rules for the default VPC's SG | bool | `true` | no |
 | enable_dns_hostnames | A boolean flag to enable/disable DNS hostnames in the VPC | bool | `true` | no |
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_vpc" "default" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = true
+  assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
   tags                             = module.label.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,12 @@ variable "enable_classiclink_dns_support" {
   default     = false
 }
 
+variable "assign_generated_ipv6_cidr_block" {
+  type        = bool
+  description = "A boolean flag to requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC"
+  default     = true
+}
+
 variable "enable_default_security_group_with_custom_rules" {
   type        = bool
   description = "A boolean flag to enable/disable custom and restricive inbound/outbound rules for the default VPC's SG"


### PR DESCRIPTION
## what
Make assign_generated_ipv6_cidr_block optional

## why

ipv6 is not always required. We keep the default to true for retro compatibility with current Cloudposse module.

## references
* https://www.terraform.io/docs/providers/aws/r/vpc.html

