### PR TITLE
A boolean flag to enable/disable Internet Gateway provisioning

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -63,7 +63,7 @@ related:
 
 # Short description of this project
 description: |-
-  Terraform module to provision a VPC with Internet Gateway.
+  Terraform module to provision a VPC with optional Internet Gateway.
 
 # How to use this project
 examples: |-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,6 +10,7 @@
 | enable_default_security_group_with_custom_rules | A boolean flag to enable/disable custom and restricive inbound/outbound rules for the default VPC's SG | bool | `true` | no |
 | enable_dns_hostnames | A boolean flag to enable/disable DNS hostnames in the VPC | bool | `true` | no |
 | enable_dns_support | A boolean flag to enable/disable DNS support in the VPC | bool | `true` | no |
+| enable_internet_gateway | A boolean flag to enable/disable Internet Gateway provisioning | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
 | instance_tenancy | A tenancy option for instances launched into the VPC | string | `default` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "aws_default_security_group" "default" {
 }
 
 resource "aws_internet_gateway" "default" {
+  count  = var.enable_internet_gateway ? 1 : 0
   vpc_id = aws_vpc.default.id
   tags   = module.label.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "igw_id" {
-  value       = aws_internet_gateway.default.id
+  value       = var.enable_internet_gateway ? aws_internet_gateway.default[0].id : ""
   description = "The ID of the Internet Gateway"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "enable_default_security_group_with_custom_rules" {
   default     = true
 }
 
+variable "enable_internet_gateway" {
+  type        = bool
+  description = "A boolean flag to enable/disable Internet Gateway provisioning"
+  default     = true
+}
+


### PR DESCRIPTION
## what
Make Internet Gateway provisioning optional. Keep default to true for retro compatibility

## why
Some VPCs require only private subnets without the need to provision an Internet Gateway
