### PR TITLE
Pass tags to the default security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,9 +25,9 @@ resource "aws_default_security_group" "default" {
   count  = var.enable_default_security_group_with_custom_rules ? 1 : 0
   vpc_id = aws_vpc.default.id
 
-  tags = {
+  tags = merge({
     Name = "Default Security Group"
-  }
+  }, module.label.tags)
 }
 
 resource "aws_internet_gateway" "default" {

--- a/main.tf
+++ b/main.tf
@@ -25,9 +25,7 @@ resource "aws_default_security_group" "default" {
   count  = var.enable_default_security_group_with_custom_rules ? 1 : 0
   vpc_id = aws_vpc.default.id
 
-  tags = merge({
-    Name = "Default Security Group"
-  }, module.label.tags)
+  tags = module.label.tags
 }
 
 resource "aws_internet_gateway" "default" {

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_default_security_group" "default" {
   count  = var.enable_default_security_group_with_custom_rules ? 1 : 0
   vpc_id = aws_vpc.default.id
 
-  tags = module.label.tags
+  tags = merge(module.label.tags, {Name = "Default Security Group"})
 }
 
 resource "aws_internet_gateway" "default" {


### PR DESCRIPTION
Currently the default security group only has as Name tag ("Default Security Group"). In our project we need to add additional tags to all objects, which is not possible with the current version of this module. I'd suggest to just use the tags from module.label, but if you insist to name them as before, we could also say `merge(module.label.tags, {"Name": "Default Security Group"})` which should override the name.