### PR TITLE
Add support for Terraform 0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.12"
 
   required_providers {
     aws      = "~> 2.0"


### PR DESCRIPTION
## what
* Relax terrafrom version constraint to support 0.13

## why
* Our team is starting to use Terraform 0.13 beta in order to take advantage of the count and for_each options on modules.
* The TF module we are working in also references the VPC. If this isn't an option we can always split the module.
* TF 13 is going to be release later this month.