### PR TITLE
Feature/13master

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
 
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   namespace   = var.namespace
   name        = var.name
   stage       = var.stage

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = "~> 0.12.0"
 
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 1.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.0"
+    }
   }
+  required_version = ">= 0.13"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.1"
+      version = ">= 3.1"
     }
     template = {
       source  = "hashicorp/template"

--- a/versions.tf
+++ b/versions.tf
@@ -3,19 +3,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.0"
+      version = "~> 3.1"
     }
     template = {
       source  = "hashicorp/template"
-      version = "~> 2.0"
+      version = "~> 2.1"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.2"
+      version = "~> 1.4"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.0"
+      version = "~> 2.1"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
## what

* Add terraform 0.13 support
* update provider requirements 

**  aws:  version = ">= 3.1"
** template: version = "~> 2.1"     
** local: version = "~> 1.4"
** null:  version = "~> 2.1"
   
## why
many modules this as a core module

## references
https://www.terraform.io/upgrade-guides/0-13.html
https://registry.terraform.io/providers/hashicorp/aws/latest

