### PR TITLE
Bump null-label version to support Terraform 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
 
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   namespace   = var.namespace
   name        = var.name
   stage       = var.stage


### PR DESCRIPTION
## what
* Bumped the pinned version of null-label to the version that supports Terraform 0.13

## why
* Module doesn't work on 0.13 without this change :)
