### PR TITLE
add ipv6_cidr_block variable to toggle IPv6 VPC association

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Available targets:
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |
+| ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | additional\_cidr\_blocks | A list of additional IPv4 CIDR blocks to associate with the VPC | `list(string)` | `null` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
+| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | cidr\_block | CIDR for the VPC | `string` | n/a | yes |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Available targets:
 |------|
 | [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/default_security_group) |
 | [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/internet_gateway) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
 | [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_ipv4_cidr_block_association) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,29 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/default_security_group) |
+| [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/internet_gateway) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
+| [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_ipv4_cidr_block_association) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_cidr\_blocks | A list of additional IPv4 CIDR blocks to associate with the VPC | `list(string)` | `null` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | cidr\_block | CIDR for the VPC | `string` | n/a | yes |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
@@ -175,7 +192,6 @@ Available targets:
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |
-| ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
@@ -200,7 +216,6 @@ Available targets:
 | vpc\_id | The ID of the VPC |
 | vpc\_ipv6\_association\_id | The association ID for the IPv6 CIDR block |
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -34,6 +34,7 @@
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |
+| ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,8 +27,8 @@
 |------|
 | [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/default_security_group) |
 | [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/internet_gateway) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
 | [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_ipv4_cidr_block_association) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,7 +36,7 @@
 |------|-------------|------|---------|:--------:|
 | additional\_cidr\_blocks | A list of additional IPv4 CIDR blocks to associate with the VPC | `list(string)` | `null` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
+| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | cidr\_block | CIDR for the VPC | `string` | n/a | yes |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,12 +14,29 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/default_security_group) |
+| [aws_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/internet_gateway) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc) |
+| [aws_vpc_ipv4_cidr_block_association](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_ipv4_cidr_block_association) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_cidr\_blocks | A list of additional IPv4 CIDR blocks to associate with the VPC | `list(string)` | `null` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| assign\_generated\_ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | cidr\_block | CIDR for the VPC | `string` | n/a | yes |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
@@ -34,7 +51,6 @@
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |
-| ipv6\_cidr\_block | Whether to assign generated ipv6 cidr block to the VPC | `bool` | `false` | no |
 | label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
@@ -59,5 +75,4 @@
 | vpc\_id | The ID of the VPC |
 | vpc\_ipv6\_association\_id | The association ID for the IPv6 CIDR block |
 | vpc\_main\_route\_table\_id | The ID of the main route table associated with this VPC |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_vpc" "default" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = true
+  assign_generated_ipv6_cidr_block = var.ipv6_cidr_block
   tags                             = module.label.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_vpc" "default" {
   enable_dns_support               = var.enable_dns_support
   enable_classiclink               = var.enable_classiclink
   enable_classiclink_dns_support   = var.enable_classiclink_dns_support
-  assign_generated_ipv6_cidr_block = var.ipv6_cidr_block
+  assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
   tags                             = module.label.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "additional_cidr_blocks" {
   default     = null
 }
 
-variable "ipv6_cidr_block" {
+variable "assign_generated_ipv6_cidr_block" {
   type        = bool
   description = "Whether to assign generated ipv6 cidr block to the VPC"
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -54,5 +54,5 @@ variable "additional_cidr_blocks" {
 variable "assign_generated_ipv6_cidr_block" {
   type        = bool
   description = "Whether to assign generated ipv6 cidr block to the VPC"
-  default     = false
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "additional_cidr_blocks" {
   description = "A list of additional IPv4 CIDR blocks to associate with the VPC"
   default     = null
 }
+
+variable "ipv6_cidr_block" {
+  type        = bool
+  description = "Whether to assign generated ipv6 cidr block to the VPC"
+  default     = false
+}


### PR DESCRIPTION
## what
* Add ipv6_cidr_block variable to toggle IPv6 VPC association.


## why
* This change allows the user to decide if IPv6 CIDR block should be associated to the VPC or not, since there are cases where the current behavior (assign_generated_ipv6_cidr_block = true) is not desired.

## references
* Apparently, issue #15 is not a problem anymore when `assign_generated_ipv6_cidr_block = false`.  I was able to get empty strings as output of `vpc_ipv6_association_id` and `ipv6_cidr_block`.
* This PR closes #59

