### PR TITLE
Update vpc-endpoints submodule docs, examples/vpc-endpoints use null label

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ module "vpc_endpoints" {
     "ec2" = {
       name                = "ec2"
       security_group_ids  = ["sg-12341234123412345"]
-      subnet_ids          = [module.dynamic_subnets.private_subnet_ids[0]]
+      subnet_ids          = module.dynamic_subnets.private_subnet_ids
       policy              = null
       private_dns_enabled = false
     }

--- a/README.yaml
+++ b/README.yaml
@@ -135,7 +135,7 @@ examples: |-
       "ec2" = {
         name                = "ec2"
         security_group_ids  = ["sg-12341234123412345"]
-        subnet_ids          = [module.dynamic_subnets.private_subnet_ids[0]]
+        subnet_ids          = module.dynamic_subnets.private_subnet_ids
         policy              = null
         private_dns_enabled = false
       }

--- a/examples/vpc-endpoints/main.tf
+++ b/examples/vpc-endpoints/main.tf
@@ -76,6 +76,24 @@ module "subnets" {
   context = module.this.context
 }
 
+module "ec2_vpc_endpoint_sg_label" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
+
+  attributes = ["ec2-vpc-endpoint-sg"]
+
+  context = module.this.context
+}
+
+module "kinesis_vpc_endpoint_sg_label" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
+
+  attributes = ["kinesis-vpc-endpoint-sg"]
+
+  context = module.this.context
+}
+
 resource "aws_security_group" "ec2_vpc_endpoint_sg" {
   vpc_id = module.vpc.vpc_id
   ingress {
@@ -86,9 +104,7 @@ resource "aws_security_group" "ec2_vpc_endpoint_sg" {
     description = "Security Group for EC2 Interface VPC Endpoint"
   }
 
-  tags = merge(
-    module.this.tags,
-  { Name = "${module.this.id}-ec2-vpc-endpoint-sg" })
+  tags = module.ec2_vpc_endpoint_sg_label.tags
 }
 
 resource "aws_security_group" "kinesis_vpc_endpoint_sg" {
@@ -101,9 +117,7 @@ resource "aws_security_group" "kinesis_vpc_endpoint_sg" {
     description = "Security Group for Kinesis Interface VPC Endpoint"
   }
 
-  tags = merge(
-    module.this.tags,
-  { Name = "${module.this.id}-kinesis-vpc-endpoint-sg" })
+  tags = module.kinesis_vpc_endpoint_sg_label.tags
 }
 
 resource "aws_vpc_endpoint_route_table_association" "s3_gateway_vpc_endpoint_route_table_association" {

--- a/modules/vpc-endpoints/README.md
+++ b/modules/vpc-endpoints/README.md
@@ -17,7 +17,11 @@ Submodule for provisioning Gateway and/or Interface VPC Endpoints to the VPC cre
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gateway_endpoint_label"></a> [gateway\_endpoint\_label](#module\_gateway\_endpoint\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_interface_endpoint_label"></a> [interface\_endpoint\_label](#module\_interface\_endpoint\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
 ## Resources
 
@@ -25,7 +29,6 @@ No modules.
 |------|------|
 | [aws_vpc_endpoint.gateway_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.interface_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
-| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [aws_vpc_endpoint_service.gateway_endpoint_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 | [aws_vpc_endpoint_service.interface_endpoint_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 
@@ -33,8 +36,23 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_gateway_vpc_endpoints"></a> [gateway\_vpc\_endpoints](#input\_gateway\_vpc\_endpoints) | A map of Gateway VPC Endpoints to provision into the VPC. This is a map of objects with the following valid attributes: 'name' can either be one of 's3' or 'dynamodb'; 'policy' is optional and can be specified as null. | <pre>map(object({<br>    name   = string<br>    policy = string<br>  }))</pre> | `{}` | no |
-| <a name="input_interface_vpc_endpoints"></a> [interface\_vpc\_endpoints](#input\_interface\_vpc\_endpoints) | A map of Interface VPC Endpoints to provision into the VPC. This is a map of objects with the following valid attributes: 'name', 'security\_group\_ids' are required; 'policy' and 'subnet\_ids' are optional and can be specified as null and as an empty list, respectively. | <pre>map(object({<br>    name               = string<br>    subnet_ids         = list(string)<br>    policy             = string<br>    security_group_ids = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_gateway_vpc_endpoints"></a> [gateway\_vpc\_endpoints](#input\_gateway\_vpc\_endpoints) | A map of Gateway VPC Endpoints to provision into the VPC. This is a map of objects with the following valid attributes: 'name' (either be one of 's3' or 'dynamodb') is required; 'policy' is optional and can be specified as null. | <pre>map(object({<br>    name   = string<br>    policy = string<br>  }))</pre> | `{}` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_interface_vpc_endpoints"></a> [interface\_vpc\_endpoints](#input\_interface\_vpc\_endpoints) | A map of Interface VPC Endpoints to provision into the VPC. This is a map of objects with the following valid attributes: 'name', 'security\_group\_ids', 'private\_dns\_enabled' are required; 'policy' and 'subnet\_ids' are optional and can be specified as null and as an empty list, respectively. | <pre>map(object({<br>    name                = string<br>    subnet_ids          = list(string)<br>    policy              = string<br>    security_group_ids  = list(string)<br>    private_dns_enabled = bool<br>  }))</pre> | `{}` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints will be created (e.g. `vpc-aceb2723`) | `string` | n/a | yes |
 
 ## Outputs


### PR DESCRIPTION
## what
* Update docs for `vpc-endpoints` submodule using `terraform-docs`
* Update `examples/vpc-endpoints` to not manually override tags for aws_security_group resources in examples/vpc-endpoints — insantiate a new null label module and supply it attributes.

## why
* The `vpc-endpoints` submodule generated docs are out-of-date.
* The use of tag overrides in `examples/vpc-endpoints` is not in line with CloudPosse style.

## references
* #82 

