### PR TITLE
Fix: fix var.enabled conditional Logic within for_each Meta-argument in vpc-endpoints Submodule

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -18,7 +18,7 @@ module "gateway_endpoint_label" {
   source  = "cloudposse/label/null"
   version = "0.24.1"
 
-  for_each   = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : set()
+  for_each   = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : {}
   attributes = [each.key]
 
   context = module.this.context
@@ -28,14 +28,14 @@ module "interface_endpoint_label" {
   source  = "cloudposse/label/null"
   version = "0.24.1"
 
-  for_each   = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : set()
+  for_each   = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : {}
   attributes = [each.key]
 
   context = module.this.context
 }
 
 resource "aws_vpc_endpoint" "gateway_endpoint" {
-  for_each          = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : set()
+  for_each          = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : {}
   service_name      = data.aws_vpc_endpoint_service.gateway_endpoint_service[each.key].service_name
   policy            = var.gateway_vpc_endpoints[each.key].policy
   vpc_endpoint_type = data.aws_vpc_endpoint_service.gateway_endpoint_service[each.key].service_type
@@ -45,7 +45,7 @@ resource "aws_vpc_endpoint" "gateway_endpoint" {
 }
 
 resource "aws_vpc_endpoint" "interface_endpoint" {
-  for_each            = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : set()
+  for_each            = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : {}
   service_name        = data.aws_vpc_endpoint_service.interface_endpoint_service[each.key].service_name
   policy              = var.interface_vpc_endpoints[each.key].policy
   security_group_ids  = var.interface_vpc_endpoints[each.key].security_group_ids


### PR DESCRIPTION
## what
* Fix var.enabled conditional logic within for_each meta-argument in `vpc-endpoints` submodule

## why
* set() is neither a real Terraform function nor will the valid toset([]) work in this instance of for_each (due to type mismatch in the ternary operator), however due to the short-circuit with enabled=true, this wasn't picked up in tests.

## references
* #82 

