### PR TITLE
Fix: Bridgecrew Failed Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -275,8 +276,6 @@ Check out these related projects.
 - [terraform-aws-dynamic-subnets](https://github.com/cloudposse/terraform-aws-dynamic-subnets) - Terraform module for public and private subnets provisioning in existing VPC
 - [terraform-aws-multi-az-subnets](https://github.com/cloudposse/terraform-aws-multi-az-subnets) - Terraform module for multi-AZ public and private subnets provisioning
 - [terraform-aws-named-subnets](https://github.com/cloudposse/terraform-aws-named-subnets) - Terraform module for named subnets provisioning.
-
-
 
 ## Help
 

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,20 @@ resource "aws_default_security_group" "default" {
   count  = local.enable_default_security_group_with_custom_rules
   vpc_id = join("", aws_vpc.default.*.id)
 
+  ingress {
+    protocol  = "-1"
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags = merge(module.label.tags, { Name = "Default Security Group" })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,22 +28,9 @@ resource "aws_vpc" "default" {
 
 # If `aws_default_security_group` is not defined, it would be created implicitly with access `0.0.0.0/0`
 resource "aws_default_security_group" "default" {
-  count  = local.enable_default_security_group_with_custom_rules
+  count = local.enable_default_security_group_with_custom_rules
+  #checkov:skip=BC_AWS_NETWORKING_4: This Bridgecrew policy checks for explicit ingress/egress blocks, however this default security group implementation does not add any inbound or outbound rules and is therefore inherently secure.
   vpc_id = join("", aws_vpc.default.*.id)
-
-  ingress {
-    protocol  = "-1"
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   tags = merge(module.label.tags, { Name = "Default Security Group" })
 }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "label" {
 
 resource "aws_vpc" "default" {
   count = local.enabled ? 1 : 0
-  #checkov:skip=BC_AWS_LOGGING_9: VPC Flow Logs are meant to be enabled by terraform-aws-vpc-flow-logs-s3-bucket and/or terraform-aws-cloudwatch-flow-logs
+  #bridgecrew:skip=BC_AWS_LOGGING_9:VPC Flow Logs are meant to be enabled by terraform-aws-vpc-flow-logs-s3-bucket and/or terraform-aws-cloudwatch-flow-logs
   cidr_block                       = var.cidr_block
   instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames
@@ -29,7 +29,7 @@ resource "aws_vpc" "default" {
 # If `aws_default_security_group` is not defined, it would be created implicitly with access `0.0.0.0/0`
 resource "aws_default_security_group" "default" {
   count = local.enable_default_security_group_with_custom_rules
-  #checkov:skip=BC_AWS_NETWORKING_4: This Bridgecrew policy checks for explicit ingress/egress blocks, however this default security group implementation does not add any inbound or outbound rules and is therefore inherently secure.
+  #bridgecrew:skip=BC_AWS_NETWORKING_4:This Bridgecrew policy checks for explicit ingress/egress blocks, however this default security group implementation does not add any inbound or outbound rules and is therefore inherently secure.
   vpc_id = join("", aws_vpc.default.*.id)
 
   tags = merge(module.label.tags, { Name = "Default Security Group" })

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,8 @@ module "label" {
 }
 
 resource "aws_vpc" "default" {
-  count                            = local.enabled ? 1 : 0
+  count = local.enabled ? 1 : 0
+  #checkov:skip=BC_AWS_LOGGING_9: VPC Flow Logs are meant to be enabled by terraform-aws-vpc-flow-logs-s3-bucket and/or terraform-aws-cloudwatch-flow-logs
   cidr_block                       = var.cidr_block
   instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "label" {
 resource "aws_vpc" "default" {
   count = local.enabled ? 1 : 0
   #bridgecrew:skip=BC_AWS_LOGGING_9:VPC Flow Logs are meant to be enabled by terraform-aws-vpc-flow-logs-s3-bucket and/or terraform-aws-cloudwatch-flow-logs
+  #bridgecrew:skip=BC_AWS_NETWORKING_4:See aws_default_security_group.default for comments
   cidr_block                       = var.cidr_block
   instance_tenancy                 = var.instance_tenancy
   enable_dns_hostnames             = var.enable_dns_hostnames


### PR DESCRIPTION
## what
* Disable bridgecrew check for VPC Flow Logs on VPC, because CloudPosse has modules in place to handle VPC Flow Log enablement.
* Skip Bridgecrew check on aws_default_security_group ingresses/egresses as the default security group implementation does not include any ingress/egress rules and is inherently secure.

## why
* Bridgecrew benchmarks are being failed as a result of `BC_AWS_LOGGING_9` and `BC_AWS_NETWORKING_4` failing.

## references
* https://docs.bridgecrew.io/docs/networking_4
* https://docs.bridgecrew.io/docs/logging_9-enable-vpc-flow-logging

