### PR TITLE
Add `vpc` output for all of `aws_vpc.default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Available targets:
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | VPC Security Group ARN |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | VPC Security Group ID |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | VPC Security Group name |
+| <a name="output_vpc"></a> [vpc](#output\_vpc) | The `aws_vpc.default` resource |
 | <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
 | <a name="output_vpc_default_network_acl_id"></a> [vpc\_default\_network\_acl\_id](#output\_vpc\_default\_network\_acl\_id) | The ID of the network ACL created by default on VPC creation |
 | <a name="output_vpc_default_route_table_id"></a> [vpc\_default\_route\_table\_id](#output\_vpc\_default\_route\_table\_id) | The ID of the route table created by default on VPC creation |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -74,6 +74,7 @@
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | VPC Security Group ARN |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | VPC Security Group ID |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | VPC Security Group name |
+| <a name="output_vpc"></a> [vpc](#output\_vpc) | The `aws_vpc.default` resource |
 | <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC |
 | <a name="output_vpc_default_network_acl_id"></a> [vpc\_default\_network\_acl\_id](#output\_vpc\_default\_network\_acl\_id) | The ID of the network ACL created by default on VPC creation |
 | <a name="output_vpc_default_route_table_id"></a> [vpc\_default\_route\_table\_id](#output\_vpc\_default\_route\_table\_id) | The ID of the route table created by default on VPC creation |

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "igw_id" {
   description = "The ID of the Internet Gateway"
 }
 
+output "vpc" {
+  value       = join("", aws_vpc.default.*.id)
+  description = "The `aws_vpc.default` resource"
+}
+
 output "vpc_id" {
   value       = join("", aws_vpc.default.*.id)
   description = "The ID of the VPC"


### PR DESCRIPTION
## what
* Add `vpc` output for all of `aws_vpc.default`

## why
* This returns the output for the entire [`aws_vpc`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc#attributes-reference) so when additional outputs are added to the resource itself, the module will also output them without having to create individual outputs for each resource attribute.

## references
N/A

