### PR TITLE
Fix syntax error in example

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module "dynamic_subnets" {
   name               = "app"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   vpc_id             = module.vpc.vpc_id
-  igw_id             = [module.vpc.igw_id]
+  igw_id             = module.vpc.igw_id
   cidr_block         = "10.0.0.0/16"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module "dynamic_subnets" {
   name               = "app"
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   vpc_id             = module.vpc.vpc_id
-  igw_id             = module.vpc.igw_id
+  igw_id             = [module.vpc.igw_id]
   cidr_block         = "10.0.0.0/16"
 }
 ```

--- a/README.yaml
+++ b/README.yaml
@@ -105,7 +105,7 @@ examples: |-
     name               = "app"
     availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
     vpc_id             = module.vpc.vpc_id
-    igw_id             = module.vpc.igw_id
+    igw_id             = [module.vpc.igw_id]
     cidr_block         = "10.0.0.0/16"
   }
   ```


### PR DESCRIPTION
Fixes a syntax error in the "Full example with terraform-aws-dynamic-subnets" code that results in a `terraform plan` failure.

## what
* The example presented with `dynamic-subnets` generates a syntax error during `terraform plan`

## why
* Improves documentation reliability