### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module "dynamic_subnets" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   vpc_id             = module.vpc.vpc_id
   igw_id             = [module.vpc.igw_id]
-  cidr_block         = "10.0.0.0/16"
+  ipv4_cidr_block    = ["10.0.0.0/16"]
 }
 ```
 


### PR DESCRIPTION
## what
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

cidr_block is no longer used in dynamic_subnets, it appears to have been moved to ipv4_cidr_block.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
[dynamic subnets ipv4_cidr_block](https://github.com/cloudposse/terraform-aws-dynamic-subnets?tab=readme-ov-file#input_ipv4_cidr_block)