### PR TITLE
Fixes "Error: no association of default Security Group (sg-XXX) with VPC Endpoint (vpce-YYY)"

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -43,23 +43,6 @@ locals {
   }
 }
 
-# Unfortunately, the AWS provider makes us jump through hoops to deal with the
-# association of an endpoint interface with the default VPC security group.
-# See https://github.com/hashicorp/terraform-provider-aws/issues/27100
-data "aws_security_group" "default" {
-  count = local.enabled ? 1 : 0
-
-  filter {
-    name   = "group-name"
-    values = ["default"]
-  }
-
-  filter {
-    name   = "vpc-id"
-    values = [var.vpc_id]
-  }
-}
-
 data "aws_vpc_endpoint_service" "gateway_endpoint_service" {
   for_each     = local.enabled ? var.gateway_vpc_endpoints : {}
   service      = var.gateway_vpc_endpoints[each.key].name


### PR DESCRIPTION
This PR updates the `vpc-endpoints` module to prevent recurring no association of default Security Group (...) with VPC Endpoint (...) errors when managing Interface VPC Endpoints. 
See also https://github.com/cloudposse-terraform-components/aws-vpc/issues/49.

The issue occurred because AWS automatically attaches the default VPC security group to an Interface endpoint when no SGs are specified at creation. The module previously relied on `replace_default_association` to swap it out for the desired SG. This worked only on the first run - subsequent runs failed because the default SG was no longer attached.

## Changes
1. Attach first SG at creation time
   * Added `security_group_ids` to `aws_vpc_endpoint.interface_endpoint` with the first SG from `var.interface_vpc_endpoints`.
   * Prevents AWS from attaching the default SG and removes the need for `replace_default_association`.
2. Limit SG associations to `index > 0`
    * Updated `security_group_associations_list` and `security_group_associations_map` locals to only include SGs beyond the first one.
    * Ensures Terraform doesn’t try to re-attach the already-attached first SG.
3. Remove `replace_default_association`
    * Association resources now only attach additional SGs.
    * Eliminates fragile “replace default” logic that failed on repeated applies.

## Benefits
* Idempotent applies — no more failing after the first run.
* Simpler logic — no special-case handling for the default SG.
* Clean AWS state — the default SG is never attached in the first place.

## Testing
* Applied changes in a test environment with multiple endpoints and SGs.
* Verified that:
   * First SG is attached at endpoint creation.
   * Additional SGs are attached via association resources.
   * No errors occur on repeated terraform apply runs.
