### PR TITLE
fix: use toset(keys(...)) in vpc-endpoints for_each to avoid deprecated .region schema walk

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -59,7 +59,7 @@ module "gateway_endpoint_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  for_each   = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : {}
+  for_each   = local.enabled ? toset(keys(data.aws_vpc_endpoint_service.gateway_endpoint_service)) : toset([])
   attributes = [each.key]
 
   context = module.this.context
@@ -69,14 +69,14 @@ module "interface_endpoint_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  for_each   = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : {}
+  for_each   = local.enabled ? toset(keys(data.aws_vpc_endpoint_service.interface_endpoint_service)) : toset([])
   attributes = [each.key]
 
   context = module.this.context
 }
 
 resource "aws_vpc_endpoint" "gateway_endpoint" {
-  for_each          = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : {}
+  for_each          = local.enabled ? toset(keys(data.aws_vpc_endpoint_service.gateway_endpoint_service)) : toset([])
   service_name      = data.aws_vpc_endpoint_service.gateway_endpoint_service[each.key].service_name
   policy            = var.gateway_vpc_endpoints[each.key].policy
   vpc_endpoint_type = data.aws_vpc_endpoint_service.gateway_endpoint_service[each.key].service_type
@@ -93,7 +93,7 @@ resource "aws_vpc_endpoint_route_table_association" "gateway" {
 }
 
 resource "aws_vpc_endpoint" "interface_endpoint" {
-  for_each            = local.enabled ? data.aws_vpc_endpoint_service.interface_endpoint_service : {}
+  for_each            = local.enabled ? toset(keys(data.aws_vpc_endpoint_service.interface_endpoint_service)) : toset([])
   service_name        = data.aws_vpc_endpoint_service.interface_endpoint_service[each.key].service_name
   policy              = var.interface_vpc_endpoints[each.key].policy
   vpc_endpoint_type   = data.aws_vpc_endpoint_service.interface_endpoint_service[each.key].service_type


### PR DESCRIPTION
## what

- Replace `for_each = ... ? data.aws_vpc_endpoint_service.X : {}` with `for_each = ... ? toset(keys(data.aws_vpc_endpoint_service.X)) : toset([])` in all four `for_each` expressions in `modules/vpc-endpoints/main.tf`

## why

- Passing the full data source map to `for_each` causes Terraform/OpenTofu to walk the entire `aws_vpc_endpoint_service` schema, which surfaces a deprecation warning for the `region` attribute (replaced by `service_region` in AWS provider v6.x):
  ```
  Warning: Value derived from a deprecated source
    on modules/vpc-endpoints/main.tf line 62, in module "gateway_endpoint_label":
    62:   for_each = local.enabled ? data.aws_vpc_endpoint_service.gateway_endpoint_service : {}
  This value's attribute ["dynamodb"].region is derived from
  data.aws_vpc_endpoint_service.gateway_endpoint_service.region, which is deprecated.
  ```
- None of the four affected blocks use `each.value` — label modules only reference `each.key`, and endpoint resources access data source attributes directly via `data.aws_vpc_endpoint_service.X[each.key].attr`. Using `toset(keys(...))` keeps the same string keys, so state is unaffected and no migration is needed

## references

- Fixes #169
